### PR TITLE
Convert monads to use readonly record structs

### DIFF
--- a/src/Monads/Exceptional.cs
+++ b/src/Monads/Exceptional.cs
@@ -28,11 +28,11 @@ public enum ExceptionalState
 ///     Exceptional monad.
 /// </summary>
 /// <typeparam name="TValue">The value type.</typeparam>
-public readonly struct Exceptional<TValue> : IEquatable<Exceptional<TValue>> where TValue : notnull
+public readonly record struct Exceptional<TValue> where TValue : notnull
 {
     private readonly Exception? _exception;
-    private readonly TValue? _value;
     private readonly ExceptionalState _state;
+    private readonly TValue? _value;
 
     internal Exceptional(TValue value)
     {
@@ -66,40 +66,7 @@ public readonly struct Exceptional<TValue> : IEquatable<Exceptional<TValue>> whe
     /// <param name="exception">The exception.</param>
     public void Deconstruct(out ExceptionalState state, out TValue? value, out Exception? exception)
     {
-        state = this._state;
-        value = this._value;
-        exception = this._exception;
-    }
-
-    /// <inheritdoc cref="object" />
-    public override bool Equals(object? obj)
-    {
-        return obj is Exceptional<TValue> other && this.Equals(other);
-    }
-
-    /// <inheritdoc cref="object" />
-    public override int GetHashCode()
-    {
-        return HashCode.Combine(this._exception, this._value, (int)this._state);
-    }
-
-    /// <inheritdoc cref="object" />
-    public static bool operator ==(Exceptional<TValue> left, Exceptional<TValue> right)
-    {
-        return left.Equals(right);
-    }
-
-    /// <inheritdoc cref="object" />
-    public static bool operator !=(Exceptional<TValue> left, Exceptional<TValue> right)
-    {
-        return !(left == right);
-    }
-
-    /// <inheritdoc cref="object" />
-    public bool Equals(Exceptional<TValue> other)
-    {
-        return Equals(this._exception, other._exception) &&
-               EqualityComparer<TValue?>.Default.Equals(this._value, other._value) && this._state == other._state;
+        (state, value, exception) = (this._state, this._value, this._exception);
     }
 
     /// <summary>

--- a/src/Monads/Maybe.cs
+++ b/src/Monads/Maybe.cs
@@ -5,18 +5,23 @@ namespace SleepingBear.Monad.Monads;
 /// <summary>
 ///     Maybe monad.
 /// </summary>
-/// <typeparam name="TSome"></typeparam>
-public readonly struct Maybe<TSome> : IEquatable<Maybe<TSome>> where TSome : notnull
+/// <typeparam name="TSome">The type of the value being lifted.</typeparam>
+public readonly record struct Maybe<TSome> where TSome : notnull
 {
+    /// <summary>
+    ///     None instance.
+    /// </summary>
+    public static readonly Maybe<TSome> None = new();
+
     private readonly TSome? _value;
 
     /// <summary>
-    ///     Constructor.
+    ///     Default constructor.
     /// </summary>
-    private Maybe(bool isSome, TSome value)
+    public Maybe()
     {
-        this.IsSome = isSome;
-        this._value = value;
+        this.IsSome = false;
+        this._value = default;
     }
 
     internal Maybe(TSome? value)
@@ -26,60 +31,23 @@ public readonly struct Maybe<TSome> : IEquatable<Maybe<TSome>> where TSome : not
     }
 
     /// <summary>
-    ///     None instance.
-    /// </summary>
-    [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
-    public static readonly Maybe<TSome> None = new(false, default!);
-
-    /// <summary>
-    ///     Indicates the maybe is in the 'Some' state.
+    ///     Flag indicating a value has been lifted.
     /// </summary>
     public bool IsSome { get; }
 
     /// <summary>
-    ///     Indicates the maybe is in the 'None' state.
+    ///     Flag indicating no value has been lifted.
     /// </summary>
     public bool IsNone => !this.IsSome;
 
     /// <summary>
-    ///     Converts the maybe to a tuple.
+    ///     Deconstructs the monad.
     /// </summary>
     /// <param name="isSome">The isSome flag.</param>
-    /// <param name="value">The 'Some' value.</param>
+    /// <param name="value">The lifted value.</param>
     public void Deconstruct(out bool isSome, out TSome? value)
     {
-        isSome = this.IsSome;
-        value = this._value;
-    }
-
-    /// <inheritdoc cref="object" />
-    public override bool Equals(object? obj)
-    {
-        return obj is Maybe<TSome> other && this.Equals(other);
-    }
-
-    /// <inheritdoc cref="object" />
-    public override int GetHashCode()
-    {
-        return HashCode.Combine(this._value, this.IsSome);
-    }
-
-    /// <inheritdoc cref="object" />
-    public static bool operator ==(Maybe<TSome> left, Maybe<TSome> right)
-    {
-        return left.Equals(right);
-    }
-
-    /// <inheritdoc cref="object" />
-    public static bool operator !=(Maybe<TSome> left, Maybe<TSome> right)
-    {
-        return !(left == right);
-    }
-
-    /// <inheritdoc cref="object" />
-    public bool Equals(Maybe<TSome> other)
-    {
-        return EqualityComparer<TSome?>.Default.Equals(this._value, other._value) && this.IsSome == other.IsSome;
+        (isSome, value) = (this.IsSome, this._value);
     }
 
     /// <summary>

--- a/src/Monads/Result.cs
+++ b/src/Monads/Result.cs
@@ -29,12 +29,12 @@ public enum ResultState
 ///     Result monad.
 /// </summary>
 /// <typeparam name="TOk">The OK type.</typeparam>
-public readonly struct Result<TOk> : IEquatable<Result<TOk>>
+public readonly record struct Result<TOk>
     where TOk : notnull
 {
-    private readonly ResultState _state;
-    private readonly TOk? _ok;
     private readonly Error? _error;
+    private readonly TOk? _ok;
+    private readonly ResultState _state;
 
     internal Result(TOk ok)
     {
@@ -68,45 +68,7 @@ public readonly struct Result<TOk> : IEquatable<Result<TOk>>
     /// <param name="error">The error value.</param>
     public void Deconstruct(out ResultState state, out TOk? ok, out Error? error)
     {
-        state = this._state;
-        ok = this._ok;
-        error = this._error;
-    }
-
-    /// <inheritdoc cref="object" />
-    public override bool Equals(object? obj)
-    {
-        return obj is Result<TOk> other && this.Equals(other);
-    }
-
-    /// <inheritdoc cref="object" />
-    public override int GetHashCode()
-    {
-        return HashCode.Combine((int)this._state, this._ok, this._error);
-    }
-
-    /// <summary>
-    ///     Equality operator.
-    /// </summary>
-    public static bool operator ==(Result<TOk> left, Result<TOk> right)
-    {
-        return left.Equals(right);
-    }
-
-    /// <summary>
-    ///     Inequality operator.
-    /// </summary>
-    public static bool operator !=(Result<TOk> left, Result<TOk> right)
-    {
-        return !(left == right);
-    }
-
-    /// <inheritdoc cref="IEquatable{T}" />
-    public bool Equals(Result<TOk> other)
-    {
-        return this._state == other._state &&
-               EqualityComparer<TOk?>.Default.Equals(this._ok, other._ok) &&
-               Equals(this._error, other._error);
+        (state, ok, error) = (this._state, this._ok, this._error);
     }
 
     /// <summary>

--- a/src/Monads/Validation.cs
+++ b/src/Monads/Validation.cs
@@ -6,11 +6,10 @@ namespace SleepingBear.Monad.Monads;
 /// <summary>
 ///     Validation monad.
 /// </summary>
-public readonly struct Validation<TValue> : IEquatable<Validation<TValue>> where TValue : notnull
+public readonly record struct Validation<TValue> where TValue : notnull
 {
-    private readonly TValue? _value;
-
     private readonly ImmutableList<Error>? _errors;
+    private readonly TValue? _value;
 
     internal Validation(TValue value)
     {
@@ -46,42 +45,6 @@ public readonly struct Validation<TValue> : IEquatable<Validation<TValue>> where
     /// </summary>
     public bool IsInvalid => !this.IsValid;
 
-    /// <inheritdoc />
-    public override bool Equals(object? obj)
-    {
-        return obj is Validation<TValue> other && this.Equals(other);
-    }
-
-    /// <inheritdoc />
-    public override int GetHashCode()
-    {
-        return HashCode.Combine(this._value, this._errors, this.IsValid);
-    }
-
-    /// <summary>
-    ///     Equality operator.
-    /// </summary>
-    public static bool operator ==(Validation<TValue> left, Validation<TValue> right)
-    {
-        return left.Equals(right);
-    }
-
-    /// <summary>
-    ///     Inequality operator.
-    /// </summary>
-    public static bool operator !=(Validation<TValue> left, Validation<TValue> right)
-    {
-        return !(left == right);
-    }
-
-    /// <inheritdoc cref="IEquatable{T}" />
-    /// .
-    public bool Equals(Validation<TValue> other)
-    {
-        return EqualityComparer<TValue?>.Default.Equals(this._value, other._value) &&
-               Equals(this._errors, other._errors) && this.IsValid == other.IsValid;
-    }
-
     /// <summary>
     ///     Deconstructs the validation monad.
     /// </summary>
@@ -90,8 +53,6 @@ public readonly struct Validation<TValue> : IEquatable<Validation<TValue>> where
     /// <param name="errors">The collection of errors.</param>
     public void Deconstruct(out bool isValid, out TValue? value, out ImmutableList<Error>? errors)
     {
-        value = this._value;
-        errors = this._errors;
-        isValid = this.IsValid;
+        (isValid, value, errors) = (this.IsValid, this._value, this._errors);
     }
 }


### PR DESCRIPTION
- Simplify deconstruct methods
- Remove boilerplate equality code