### PR TITLE
Remove state enumerations from monad structs

### DIFF
--- a/src/Errors/UnknownError.cs
+++ b/src/Errors/UnknownError.cs
@@ -1,0 +1,6 @@
+namespace SleepingBear.Monad.Errors;
+
+/// <summary>
+///     Unknown error.
+/// </summary>
+public sealed record UnknownError : Error;

--- a/src/Monads.Test/ExceptionalExtensionsTests.cs
+++ b/src/Monads.Test/ExceptionalExtensionsTests.cs
@@ -8,13 +8,6 @@ namespace SleepingBear.Monad.Monads.Test;
 internal static class ExceptionalExtensionsTests
 {
     [Test]
-    public static void ToResult_Invalid_ThrowsInvalidOperationException()
-    {
-        var exceptional = new Exceptional<int>();
-        Assert.Throws<InvalidOperationException>(() => exceptional.ToResult());
-    }
-
-    [Test]
     public static void ToResult_Value_ReturnResultOk()
     {
         _ = 1234

--- a/src/Monads.Test/ExceptionalTests.cs
+++ b/src/Monads.Test/ExceptionalTests.cs
@@ -16,24 +16,24 @@ internal static class ExceptionalTests
         {
             Assert.That(exceptional.IsValue, Is.True);
             Assert.That(exceptional.IsException, Is.False);
-            Assert.That(state, Is.EqualTo(ExceptionalState.Value));
+            Assert.That(state, Is.True);
             Assert.That(value, Is.EqualTo(1234));
             Assert.That(exception, Is.Null);
         });
     }
 
     [Test]
-    public static void Ctor_Default_SetInvalid()
+    public static void Ctor_Default_InvalidOperationException()
     {
         var exceptional = new Exceptional<int>();
-        var (state, value, exception) = exceptional;
+        var (isValue, value, exception) = exceptional;
         Assert.Multiple(() =>
         {
             Assert.That(exceptional.IsValue, Is.False);
-            Assert.That(exceptional.IsException, Is.False);
-            Assert.That(state, Is.EqualTo(ExceptionalState.Invalid));
+            Assert.That(exceptional.IsException, Is.True);
+            Assert.That(isValue, Is.False);
             Assert.That(value, Is.EqualTo(default(int)));
-            Assert.That(exception, Is.Null);
+            Assert.That(exception, Is.InstanceOf<InvalidOperationException>());
         });
     }
 
@@ -42,12 +42,12 @@ internal static class ExceptionalTests
     {
         var exception = new InvalidOperationException();
         var exceptional = new Exceptional<int>(exception);
-        var (state, value, outException) = exceptional;
+        var (isValue, value, outException) = exceptional;
         Assert.Multiple(() =>
         {
             Assert.That(exceptional.IsValue, Is.False);
             Assert.That(exceptional.IsException, Is.True);
-            Assert.That(state, Is.EqualTo(ExceptionalState.Exception));
+            Assert.That(isValue, Is.False);
             Assert.That(value, Is.EqualTo(default(int)));
             Assert.That(outException, Is.SameAs(exception));
         });

--- a/src/Monads.Test/ResultExtensionTests.cs
+++ b/src/Monads.Test/ResultExtensionTests.cs
@@ -12,10 +12,10 @@ internal static class ResultExtensionTests
     public static void ToResult_OK_ValidatesBehavior()
     {
         var result = 1234.ToResult();
-        result.Deconstruct(out var state, out var ok, out var error);
+        var (isOk, ok, error) = result;
         Assert.Multiple(() =>
         {
-            Assert.That(state, Is.EqualTo(ResultState.Ok));
+            Assert.That(isOk, Is.EqualTo(true));
             Assert.That(ok, Is.EqualTo(1234));
             Assert.That(error, Is.Null);
         });
@@ -25,14 +25,13 @@ internal static class ResultExtensionTests
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public static void ToResult_Error_ValidatesBehavior()
     {
-        var error = 1234.ToError();
-        var result = error.ToResult<string>();
-        result.Deconstruct(out var state, out var ok, out var outError);
+        var result = 1234.ToError().ToResult<string>();
+        var (isOk, ok, error) = result;
         Assert.Multiple(() =>
         {
-            Assert.That(state, Is.EqualTo(ResultState.Error));
+            Assert.That(isOk, Is.EqualTo(false));
             Assert.That(ok, Is.Null);
-            outError!.TestErrorOf<Error<int>>(e => { Assert.That(e.Value, Is.EqualTo(1234)); });
+            error!.TestErrorOf<Error<int>>(e => { Assert.That(e.Value, Is.EqualTo(1234)); });
         });
     }
 

--- a/src/Monads.Test/ResultExtensionTests.cs
+++ b/src/Monads.Test/ResultExtensionTests.cs
@@ -15,7 +15,7 @@ internal static class ResultExtensionTests
         var (isOk, ok, error) = result;
         Assert.Multiple(() =>
         {
-            Assert.That(isOk, Is.EqualTo(true));
+            Assert.That(isOk, Is.True);
             Assert.That(ok, Is.EqualTo(1234));
             Assert.That(error, Is.Null);
         });
@@ -29,7 +29,7 @@ internal static class ResultExtensionTests
         var (isOk, ok, error) = result;
         Assert.Multiple(() =>
         {
-            Assert.That(isOk, Is.EqualTo(false));
+            Assert.That(isOk, Is.False);
             Assert.That(ok, Is.Null);
             error!.TestErrorOf<Error<int>>(e => { Assert.That(e.Value, Is.EqualTo(1234)); });
         });

--- a/src/Monads.Test/ResultTests.cs
+++ b/src/Monads.Test/ResultTests.cs
@@ -32,7 +32,7 @@ internal static class ResultTests
         {
             Assert.That(result.IsOk, Is.True);
             Assert.That(result.IsError, Is.False);
-            Assert.That(isOk, Is.EqualTo(true));
+            Assert.That(isOk, Is.True);
             Assert.That(ok, Is.EqualTo(1234));
             Assert.That(error, Is.Null);
         });
@@ -46,7 +46,7 @@ internal static class ResultTests
         var (isOk, ok, error) = result;
         Assert.Multiple(() =>
         {
-            Assert.That(isOk, Is.EqualTo(false));
+            Assert.That(isOk, Is.False);
             Assert.That(ok, Is.EqualTo(0));
             error!.TestErrorOf<Error<int>>(e => { Assert.That(e.Value, Is.EqualTo(1234)); });
         });
@@ -112,7 +112,7 @@ internal static class ResultTests
                     error.TestErrorOf<Error<int>>(intError => { Assert.That(intError.Value, Is.EqualTo(1234)); });
                 });
     }
-    
+
     [Test]
     public static void Bind_Ok_MapsValue()
     {
@@ -136,7 +136,7 @@ internal static class ResultTests
                     error.TestErrorOf<Error<int>>(intError => { Assert.That(intError.Value, Is.EqualTo(1234)); });
                 });
     }
-    
+
     [Test]
     public static void Match_Ok_MapsValue()
     {
@@ -147,5 +147,4 @@ internal static class ResultTests
                 _ => 0);
         Assert.That(result, Is.EqualTo(2468));
     }
-
 }

--- a/src/Monads.Test/TaskExtensionsTests.Result.cs
+++ b/src/Monads.Test/TaskExtensionsTests.Result.cs
@@ -205,30 +205,34 @@ internal static partial class TaskExtensionsTests
     }
 
     [Test]
-    public static Task MatchAsync_ResultInvalid_ThrowsInvalidOperationException()
+    public static async Task TapAsync_Ok_CallSynchronousOkFunc()
     {
-        _ = Assert.ThrowsAsync<InvalidOperationException>(async () =>
-        {
-            _ = await new Result<int>()
-                .ToTask()
-                .MatchAsync(_ => 0.ToTask(), _ => 1.ToTask())
-                .ConfigureAwait(false);
-        });
-        return Task.CompletedTask;
+        _ = await 1234
+            .ToResult()
+            .ToTask()
+            .TapAsync(
+                ok => { Assert.That(ok, Is.EqualTo(1234)); },
+                _ => { Assert.Fail("Should not be called."); })
+            .ConfigureAwait(true);
     }
 
     [Test]
-    public static Task TapAsync_ResultInvalid_ThrowsInvalidOperationException()
+    public static async Task TapAsync_Ok_CallAsynchronousOkFunc()
     {
-        _ = Assert.ThrowsAsync<InvalidOperationException>(async () =>
-        {
-            _ = await new Result<int>()
-                .ToTask()
-                .TapAsync(
-                    async _ => { await Task.Delay(0).ConfigureAwait(false); },
-                    async _ => { await Task.Delay(0).ConfigureAwait(false); })
-                .ConfigureAwait(false);
-        });
-        return Task.CompletedTask;
+        _ = await 1234
+            .ToResult()
+            .ToTask()
+            .TapAsync(
+                ok =>
+                {
+                    Assert.That(ok, Is.EqualTo(1234));
+                    return Task.CompletedTask;
+                },
+                _ =>
+                {
+                    Assert.Fail("Should not be called.");
+                    return Task.CompletedTask;
+                })
+            .ConfigureAwait(true);
     }
 }

--- a/src/Monads/Exceptional.cs
+++ b/src/Monads/Exceptional.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 namespace SleepingBear.Monad.Monads;

--- a/src/Monads/Exceptional.cs
+++ b/src/Monads/Exceptional.cs
@@ -4,69 +4,57 @@ using System.Diagnostics.CodeAnalysis;
 namespace SleepingBear.Monad.Monads;
 
 /// <summary>
-///     Exceptional monad state.
-/// </summary>
-public enum ExceptionalState
-{
-    /// <summary>
-    ///     Indicates that monad is invalid due to default construction.
-    /// </summary>
-    Invalid = 0,
-
-    /// <summary>
-    ///     Indicates the monad contains a value.
-    /// </summary>
-    Value,
-
-    /// <summary>
-    ///     Indicates the monad contains <see cref="Exception" />.
-    /// </summary>
-    Exception
-}
-
-/// <summary>
 ///     Exceptional monad.
 /// </summary>
 /// <typeparam name="TValue">The value type.</typeparam>
 public readonly record struct Exceptional<TValue> where TValue : notnull
 {
     private readonly Exception? _exception;
-    private readonly ExceptionalState _state;
     private readonly TValue? _value;
+
+    /// <summary>
+    ///     Default constructor.
+    /// </summary>
+    public Exceptional()
+    {
+        this.IsValue = false;
+        this._value = default;
+        this._exception = new InvalidOperationException("Exceptional<TValue> created using default constructor.");
+    }
 
     internal Exceptional(TValue value)
     {
+        this.IsValue = true;
         this._value = value;
         this._exception = null;
-        this._state = ExceptionalState.Value;
     }
 
     internal Exceptional(Exception exception)
     {
+        this.IsValue = false;
         this._value = default;
         this._exception = exception;
-        this._state = ExceptionalState.Exception;
     }
 
     /// <summary>
     ///     Property indicating the monad contains a value.
     /// </summary>
-    public bool IsValue => this._state == ExceptionalState.Value;
+    public bool IsValue { get; }
 
     /// <summary>
     ///     Property indicating the monad contains an exception.
     /// </summary>
-    public bool IsException => this._state == ExceptionalState.Exception;
+    public bool IsException => !this.IsValue;
 
     /// <summary>
     ///     Deconstructs the monad.
     /// </summary>
-    /// <param name="state">The state.</param>
+    /// <param name="isValue">The state.</param>
     /// <param name="value">The value.</param>
     /// <param name="exception">The exception.</param>
-    public void Deconstruct(out ExceptionalState state, out TValue? value, out Exception? exception)
+    public void Deconstruct(out bool isValue, out TValue? value, out Exception? exception)
     {
-        (state, value, exception) = (this._state, this._value, this._exception);
+        (isValue, value, exception) = (this.IsValue, this._value, this._exception);
     }
 
     /// <summary>
@@ -85,13 +73,9 @@ public readonly record struct Exceptional<TValue> where TValue : notnull
     {
         ArgumentNullException.ThrowIfNull(mapFunc);
 
-        return this._state switch
-        {
-            ExceptionalState.Value => new Exceptional<TValueOut>(mapFunc(this._value!)),
-            ExceptionalState.Exception => new Exceptional<TValueOut>(this._exception!),
-            ExceptionalState.Invalid => throw new InvalidOperationException(),
-            _ => throw new UnreachableException()
-        };
+        return this.IsValue
+            ? new Exceptional<TValueOut>(mapFunc(this._value!))
+            : new Exceptional<TValueOut>(this._exception!);
     }
 
     /// <summary>
@@ -114,23 +98,16 @@ public readonly record struct Exceptional<TValue> where TValue : notnull
         ArgumentNullException.ThrowIfNull(valueAction);
         ArgumentNullException.ThrowIfNull(exceptionAction);
 
-        switch (this._state)
+        if (this.IsValue)
         {
-            case ExceptionalState.Value:
-            {
-                valueAction(this._value!);
-                return this;
-            }
-            case ExceptionalState.Exception:
-            {
-                exceptionAction(this._exception!);
-                return this;
-            }
-            case ExceptionalState.Invalid:
-                throw new InvalidOperationException();
-            default:
-                throw new UnreachableException();
+            valueAction(this._value!);
         }
+        else
+        {
+            exceptionAction(this._exception!);
+        }
+
+        return this;
     }
 
     /// <summary>
@@ -150,13 +127,9 @@ public readonly record struct Exceptional<TValue> where TValue : notnull
     {
         ArgumentNullException.ThrowIfNull(bindFunc);
 
-        return this._state switch
-        {
-            ExceptionalState.Value => bindFunc(this._value!),
-            ExceptionalState.Exception => new Exceptional<TValueOut>(this._exception!),
-            ExceptionalState.Invalid => throw new InvalidOperationException(),
-            _ => throw new UnreachableException()
-        };
+        return this.IsValue
+            ? bindFunc(this._value!)
+            : new Exceptional<TValueOut>(this._exception!);
     }
 
     /// <summary>
@@ -169,19 +142,10 @@ public readonly record struct Exceptional<TValue> where TValue : notnull
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public bool Try([NotNullWhen(true)] out TValue? value)
     {
-        switch (this._state)
-        {
-            case ExceptionalState.Invalid:
-                value = default;
-                return false;
-            case ExceptionalState.Value:
-                value = this._value!;
-                return true;
-            case ExceptionalState.Exception:
-                throw new InvalidOperationException();
-            default:
-                throw new UnreachableException();
-        }
+        value = this.IsValue
+            ? this._value!
+            : default;
+        return this.IsValue;
     }
 
 
@@ -200,12 +164,8 @@ public readonly record struct Exceptional<TValue> where TValue : notnull
         ArgumentNullException.ThrowIfNull(valueFunc);
         ArgumentNullException.ThrowIfNull(exceptionFunc);
 
-        return this._state switch
-        {
-            ExceptionalState.Value => valueFunc(this._value!),
-            ExceptionalState.Exception => exceptionFunc(this._exception!),
-            ExceptionalState.Invalid => throw new InvalidOperationException(),
-            _ => throw new UnreachableException()
-        };
+        return this.IsValue
+            ? valueFunc(this._value!)
+            : exceptionFunc(this._exception!);
     }
 }

--- a/src/Monads/Exceptional.cs
+++ b/src/Monads/Exceptional.cs
@@ -63,8 +63,6 @@ public readonly record struct Exceptional<TValue> where TValue : notnull
     /// <param name="mapFunc">The mapping function.</param>
     /// <typeparam name="TValueOut">The output value type.</typeparam>
     /// <returns>A <see cref="Exceptional{TValue}" />.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if the state is invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     /// <remarks>
     ///     The <paramref name="mapFunc" /> should NOT throw any exceptions.
     /// </remarks>
@@ -84,8 +82,6 @@ public readonly record struct Exceptional<TValue> where TValue : notnull
     /// <param name="valueAction">The 'Value' action.</param>
     /// <param name="exceptionAction">The 'Exception' action.</param>
     /// <returns>The <see cref="Exceptional{TValue}" /> instance.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if the state is invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     /// <remarks>
     ///     The <paramref name="valueAction" /> and <paramref name="exceptionAction" /> should NOT
     ///     throw any exceptions.
@@ -116,8 +112,6 @@ public readonly record struct Exceptional<TValue> where TValue : notnull
     /// <param name="bindFunc">The binding function.</param>
     /// <typeparam name="TValueOut">The output value type.</typeparam>
     /// <returns>A <see cref="Exceptional{TValue}" />.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if the state is invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     /// <remarks>
     ///     The <paramref name="bindFunc" /> should NOT throw any exceptions.
     /// </remarks>
@@ -137,8 +131,6 @@ public readonly record struct Exceptional<TValue> where TValue : notnull
     /// </summary>
     /// <param name="value">The value.</param>
     /// <returns>True if state is 'Value', false otherwise.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if the state is invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public bool Try([NotNullWhen(true)] out TValue? value)
     {
@@ -156,8 +148,6 @@ public readonly record struct Exceptional<TValue> where TValue : notnull
     /// <param name="exceptionFunc">The 'Exception' function.</param>
     /// <typeparam name="TValueOut">The output value type.</typeparam>
     /// <returns>The matched value.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if the state is invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public TValueOut Match<TValueOut>(Func<TValue, TValueOut> valueFunc, Func<Exception, TValueOut> exceptionFunc)
     {

--- a/src/Monads/ExceptionalExtensions.cs
+++ b/src/Monads/ExceptionalExtensions.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using SleepingBear.Monad.Errors;
 

--- a/src/Monads/ExceptionalExtensions.cs
+++ b/src/Monads/ExceptionalExtensions.cs
@@ -42,13 +42,9 @@ public static class ExceptionalExtensions
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public static Result<TValue> ToResult<TValue>(this Exceptional<TValue> exceptional) where TValue : notnull
     {
-        var (state, value, exception) = exceptional;
-        return state switch
-        {
-            ExceptionalState.Value => value!.ToResult(),
-            ExceptionalState.Exception => exception!.ToError().ToResult<TValue>(),
-            ExceptionalState.Invalid => throw new InvalidOperationException(),
-            _ => throw new UnreachableException()
-        };
+        var (isValue, value, exception) = exceptional;
+        return isValue
+            ? value!.ToResult()
+            : exception!.ToError().ToResult<TValue>();
     }
 }

--- a/src/Monads/ExceptionalExtensions.cs
+++ b/src/Monads/ExceptionalExtensions.cs
@@ -37,8 +37,6 @@ public static class ExceptionalExtensions
     /// <param name="exceptional">The exceptional.</param>
     /// <typeparam name="TValue">The value type.</typeparam>
     /// <returns>A <see cref="Result{TOk}" />.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if the state is invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public static Result<TValue> ToResult<TValue>(this Exceptional<TValue> exceptional) where TValue : notnull
     {

--- a/src/Monads/Result.cs
+++ b/src/Monads/Result.cs
@@ -5,27 +5,6 @@ using SleepingBear.Monad.Errors;
 namespace SleepingBear.Monad.Monads;
 
 /// <summary>
-///     Result state enumeration.
-/// </summary>
-public enum ResultState
-{
-    /// <summary>
-    ///     Invalid state - indicates the Result struct was constructed with the default constructor.
-    /// </summary>
-    Invalid = 0,
-
-    /// <summary>
-    ///     OK state.
-    /// </summary>
-    Ok,
-
-    /// <summary>
-    ///     Error state.
-    /// </summary>
-    Error
-}
-
-/// <summary>
 ///     Result monad.
 /// </summary>
 /// <typeparam name="TOk">The OK type.</typeparam>
@@ -34,151 +13,140 @@ public readonly record struct Result<TOk>
 {
     private readonly Error? _error;
     private readonly TOk? _ok;
-    private readonly ResultState _state;
+
+    /// <summary>
+    ///     Default constructor.
+    /// </summary>
+    public Result()
+    {
+        this.IsOk = false;
+        this._ok = default;
+        this._error = new UnknownError();
+    }
 
     internal Result(TOk ok)
     {
+        this.IsOk = true;
         this._ok = ok;
         this._error = null;
-        this._state = ResultState.Ok;
     }
 
     internal Result(Error error)
     {
+        this.IsOk = false;
         this._ok = default;
         this._error = error;
-        this._state = ResultState.Error;
     }
 
     /// <summary>
     ///     Indicates the result is in the 'OK' state.
     /// </summary>
-    public bool IsOk => this._state == ResultState.Ok;
+    public bool IsOk { get; }
 
     /// <summary>
     ///     Indicates the result in the 'Error' state.
     /// </summary>
-    public bool IsError => this._state == ResultState.Error;
+    public bool IsError => !this.IsOk;
 
     /// <summary>
     ///     Deconstructs the result.
     /// </summary>
-    /// <param name="state">The state.</param>
+    /// <param name="isOk">Flag indicating the OK state.</param>
     /// <param name="ok">The OK value.</param>
     /// <param name="error">The error value.</param>
-    public void Deconstruct(out ResultState state, out TOk? ok, out Error? error)
+    public void Deconstruct(out bool isOk, out TOk? ok, out Error? error)
     {
-        (state, ok, error) = (this._state, this._ok, this._error);
+        (isOk, ok, error) = (this.IsOk, this._ok, this._error);
     }
 
     /// <summary>
     ///     Map a <see cref="Result{TOk}" />.
     /// </summary>
-    /// <param name="map">The mapping function.</param>
+    /// <param name="mapFunc">The mapping function.</param>
     /// <typeparam name="TOkOut">The output OK type.</typeparam>
     /// <returns>A <see cref="Result{TOk}" />.</returns>
     /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
     /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
-    public Result<TOkOut> Map<TOkOut>(Func<TOk, TOkOut> map) where TOkOut : notnull
+    public Result<TOkOut> Map<TOkOut>(Func<TOk, TOkOut> mapFunc) where TOkOut : notnull
     {
-        ArgumentNullException.ThrowIfNull(map);
+        ArgumentNullException.ThrowIfNull(mapFunc);
 
-        return this._state switch
-        {
-            ResultState.Ok => new Result<TOkOut>(map(this._ok!)),
-            ResultState.Error => new Result<TOkOut>(this._error!),
-            ResultState.Invalid => throw new InvalidOperationException(),
-            _ => throw new UnreachableException()
-        };
+        return this.IsOk
+            ? new Result<TOkOut>(mapFunc(this._ok!))
+            : new Result<TOkOut>(this._error!);
     }
 
     /// <summary>
     ///     Map a <see cref="Result{TOk}" />.
     /// </summary>
-    /// <param name="map">The mapping function.</param>
+    /// <param name="mapErrorFunc">The mapping function.</param>
     /// <returns>A <see cref="Result{TOk}" />.</returns>
     /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
     /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
-    public Result<TOk> MapError(Func<Error, Error> map)
+    public Result<TOk> MapError(Func<Error, Error> mapErrorFunc)
     {
-        ArgumentNullException.ThrowIfNull(map);
+        ArgumentNullException.ThrowIfNull(mapErrorFunc);
 
-        return this._state switch
-        {
-            ResultState.Ok => this,
-            ResultState.Error => new Result<TOk>(map(this._error!)),
-            ResultState.Invalid => throw new InvalidOperationException(),
-            _ => throw new UnreachableException()
-        };
+        return this.IsOk
+            ? new Result<TOk>(this._ok!)
+            : new Result<TOk>(mapErrorFunc(this._error!));
     }
 
     /// <summary>
     ///     Binds a <see cref="Result{TOk}" />.
     /// </summary>
-    /// <param name="bind">The binding function.</param>
+    /// <param name="bindFunc">The binding function.</param>
     /// <typeparam name="TOkOut">The output OK type.</typeparam>
     /// <returns>A <see cref="Result{TOk}" />.</returns>
     /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
     /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
-    public Result<TOkOut> Bind<TOkOut>(Func<TOk, Result<TOkOut>> bind) where TOkOut : notnull
+    public Result<TOkOut> Bind<TOkOut>(Func<TOk, Result<TOkOut>> bindFunc) where TOkOut : notnull
     {
-        ArgumentNullException.ThrowIfNull(bind);
+        ArgumentNullException.ThrowIfNull(bindFunc);
 
-        return this._state switch
-        {
-            ResultState.Ok => bind(this._ok!),
-            ResultState.Error => new Result<TOkOut>(this._error!),
-            ResultState.Invalid => throw new InvalidOperationException(),
-            _ => throw new UnreachableException()
-        };
+        return this.IsOk
+            ? bindFunc(this._ok!)
+            : new Result<TOkOut>(this._error!);
     }
 
     /// <summary>
     ///     Bind a <see cref="Result{TOk}" />.
     /// </summary>
-    /// <param name="bind">The binding function.</param>
+    /// <param name="bindFunc">The binding function.</param>
     /// <returns>A <see cref="Result{TOk}" />.</returns>
     /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
     /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
-    public Result<TOk> BindError(Func<Error, Result<TOk>> bind)
+    public Result<TOk> BindError(Func<Error, Result<TOk>> bindFunc)
     {
-        ArgumentNullException.ThrowIfNull(bind);
+        ArgumentNullException.ThrowIfNull(bindFunc);
 
-        return this._state switch
-        {
-            ResultState.Ok => this,
-            ResultState.Error => bind(this._error!),
-            ResultState.Invalid => throw new InvalidOperationException(),
-            _ => throw new UnreachableException()
-        };
+        return this.IsOk
+            ? new Result<TOk>(this._ok!)
+            : bindFunc(this._error!);
     }
 
     /// <summary>
     ///     Matches the <see cref="Result{TOk}" />.
     /// </summary>
-    /// <param name="ok">The OK function.</param>
-    /// <param name="error">The error function.</param>
+    /// <param name="okFunc">The OK function.</param>
+    /// <param name="errorFunc">The error function.</param>
     /// <typeparam name="TOut">The output type.</typeparam>
     /// <returns>The matched value.</returns>
     /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
     /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
-    public TOut Match<TOut>(Func<TOk, TOut> ok, Func<Error, TOut> error)
+    public TOut Match<TOut>(Func<TOk, TOut> okFunc, Func<Error, TOut> errorFunc)
     {
-        ArgumentNullException.ThrowIfNull(ok);
-        ArgumentNullException.ThrowIfNull(error);
+        ArgumentNullException.ThrowIfNull(okFunc);
+        ArgumentNullException.ThrowIfNull(errorFunc);
 
-        return this._state switch
-        {
-            ResultState.Ok => ok(this._ok!),
-            ResultState.Error => error(this._error!),
-            ResultState.Invalid => throw new InvalidOperationException(),
-            _ => throw new UnreachableException()
-        };
+        return this.IsOk
+            ? okFunc(this._ok!)
+            : errorFunc(this._error!);
     }
 
     /// <summary>
@@ -191,19 +159,10 @@ public readonly record struct Result<TOk>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public bool Try([NotNullWhen(true)] out TOk? ok)
     {
-        switch (this._state)
-        {
-            case ResultState.Ok:
-                ok = this._ok!;
-                return true;
-            case ResultState.Error:
-                ok = default;
-                return false;
-            case ResultState.Invalid:
-                throw new InvalidOperationException();
-            default:
-                throw new UnreachableException();
-        }
+        ok = this.IsOk
+            ? this._ok!
+            : default;
+        return this.IsOk;
     }
 
     /// <summary>
@@ -216,19 +175,8 @@ public readonly record struct Result<TOk>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public bool TryError([NotNullWhen(true)] out Error? error)
     {
-        switch (this._state)
-        {
-            case ResultState.Ok:
-                error = default;
-                return false;
-            case ResultState.Error:
-                error = this._error!;
-                return true;
-            case ResultState.Invalid:
-                throw new InvalidOperationException();
-            default:
-                throw new UnreachableException();
-        }
+        error = this.IsOk ? default : this._error!;
+        return !this.IsOk;
     }
 
     /// <summary>
@@ -245,18 +193,13 @@ public readonly record struct Result<TOk>
         ArgumentNullException.ThrowIfNull(okAction);
         ArgumentNullException.ThrowIfNull(errorAction);
 
-        switch (this._state)
+        if (this.IsOk)
         {
-            case ResultState.Ok:
-                okAction(this._ok!);
-                break;
-            case ResultState.Error:
-                errorAction(this._error!);
-                break;
-            case ResultState.Invalid:
-                throw new InvalidOperationException();
-            default:
-                throw new UnreachableException();
+            okAction(this._ok!);
+        }
+        else
+        {
+            errorAction(this._error!);
         }
 
         return this;

--- a/src/Monads/Result.cs
+++ b/src/Monads/Result.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using SleepingBear.Monad.Errors;
 
 namespace SleepingBear.Monad.Monads;

--- a/src/Monads/Result.cs
+++ b/src/Monads/Result.cs
@@ -65,8 +65,6 @@ public readonly record struct Result<TOk>
     /// <param name="mapFunc">The mapping function.</param>
     /// <typeparam name="TOkOut">The output OK type.</typeparam>
     /// <returns>A <see cref="Result{TOk}" />.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public Result<TOkOut> Map<TOkOut>(Func<TOk, TOkOut> mapFunc) where TOkOut : notnull
     {
@@ -82,8 +80,6 @@ public readonly record struct Result<TOk>
     /// </summary>
     /// <param name="mapErrorFunc">The mapping function.</param>
     /// <returns>A <see cref="Result{TOk}" />.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public Result<TOk> MapError(Func<Error, Error> mapErrorFunc)
     {
@@ -100,8 +96,6 @@ public readonly record struct Result<TOk>
     /// <param name="bindFunc">The binding function.</param>
     /// <typeparam name="TOkOut">The output OK type.</typeparam>
     /// <returns>A <see cref="Result{TOk}" />.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public Result<TOkOut> Bind<TOkOut>(Func<TOk, Result<TOkOut>> bindFunc) where TOkOut : notnull
     {
@@ -117,8 +111,6 @@ public readonly record struct Result<TOk>
     /// </summary>
     /// <param name="bindFunc">The binding function.</param>
     /// <returns>A <see cref="Result{TOk}" />.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public Result<TOk> BindError(Func<Error, Result<TOk>> bindFunc)
     {
@@ -136,8 +128,6 @@ public readonly record struct Result<TOk>
     /// <param name="errorFunc">The error function.</param>
     /// <typeparam name="TOut">The output type.</typeparam>
     /// <returns>The matched value.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public TOut Match<TOut>(Func<TOk, TOut> okFunc, Func<Error, TOut> errorFunc)
     {
@@ -154,8 +144,6 @@ public readonly record struct Result<TOk>
     /// </summary>
     /// <param name="ok">The 'OK' value.</param>
     /// <returns>True if OK, false otherwise.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public bool Try([NotNullWhen(true)] out TOk? ok)
     {
@@ -170,8 +158,6 @@ public readonly record struct Result<TOk>
     /// </summary>
     /// <param name="error">The 'Error' value.</param>
     /// <returns>True if error, false otherwise.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public bool TryError([NotNullWhen(true)] out Error? error)
     {
@@ -185,8 +171,6 @@ public readonly record struct Result<TOk>
     /// <param name="okAction">The OK action.</param>
     /// <param name="errorAction">The error action.</param>
     /// <returns>The result</returns>
-    /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public Result<TOk> Tap(Action<TOk> okAction, Action<Error> errorAction)
     {

--- a/src/Monads/ResultExtensions.cs
+++ b/src/Monads/ResultExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using SleepingBear.Monad.Errors;
 
 namespace SleepingBear.Monad.Monads;

--- a/src/Monads/ResultExtensions.cs
+++ b/src/Monads/ResultExtensions.cs
@@ -60,9 +60,7 @@ public static class ResultExtensions
     /// <param name="predicate">The predicate.</param>
     /// <param name="bindFunc">The binding function.</param>
     /// <typeparam name="TOk">The input OK type.</typeparam>
-    /// <returns>A <see cref="Result{TOk}" /> containing the bound value..</returns>
-    /// <exception cref="InvalidOperationException">Thrown if the result's state is invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the result's state is unknown.</exception>
+    /// <returns>A <see cref="Result{TOk}" /> containing the bound value.</returns>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public static Result<TOk> BindIf<TOk>(
         this Result<TOk> result,
@@ -87,8 +85,6 @@ public static class ResultExtensions
     /// <param name="mapFunc">The mapping function.</param>
     /// <typeparam name="TOk">The lifted value type.</typeparam>
     /// <returns>A <see cref="Result{TOk}" /> containing the mapped value.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if the result's state is invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the result's state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public static Result<TOk> MapIf<TOk>(
         this Result<TOk> result,

--- a/src/Monads/TaskExtensions.Exceptional.cs
+++ b/src/Monads/TaskExtensions.Exceptional.cs
@@ -16,8 +16,6 @@ public static partial class TaskExtensions
     /// <typeparam name="TValue">The value type.</typeparam>
     /// <typeparam name="TValueOut">The output value type.</typeparam>
     /// <returns>A <see cref="Task{TResult}" />.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public static async Task<Exceptional<TValueOut>> MapAsync<TValue, TValueOut>(
         this Task<Exceptional<TValue>> task,
@@ -40,8 +38,6 @@ public static partial class TaskExtensions
     /// <typeparam name="TValue">The value type.</typeparam>
     /// <typeparam name="TValueOut">The output value type.</typeparam>
     /// <returns>A <see cref="Task{TResult}" />.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public static async Task<Exceptional<TValueOut>> BindAsync<TValue, TValueOut>(
         this Task<Exceptional<TValue>> task,
@@ -64,8 +60,6 @@ public static partial class TaskExtensions
     /// <param name="exceptionAction">The 'Exception' action.</param>
     /// <typeparam name="TValue">The value type.</typeparam>
     /// <returns>A <see cref="Task{TResult}" />.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public static async Task<Exceptional<TValue>> TapAsync<TValue>(
         this Task<Exceptional<TValue>> task,
@@ -98,8 +92,6 @@ public static partial class TaskExtensions
     /// <typeparam name="TValue">The 'Value' type.</typeparam>
     /// <typeparam name="TValueOut">The output 'Value' type.</typeparam>
     /// <returns>A <see cref="Task{TResult}" />.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public static async Task<TValueOut> MatchAsync<TValue, TValueOut>(
         this Task<Exceptional<TValue>> task,

--- a/src/Monads/TaskExtensions.Exceptional.cs
+++ b/src/Monads/TaskExtensions.Exceptional.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 
 namespace SleepingBear.Monad.Monads;
 

--- a/src/Monads/TaskExtensions.Result.cs
+++ b/src/Monads/TaskExtensions.Result.cs
@@ -17,8 +17,6 @@ public static partial class TaskExtensions
     /// <typeparam name="TOk">The OK type.</typeparam>
     /// <typeparam name="TOkOut">The output OK type.</typeparam>
     /// <returns>A <see cref="Task{TResult}" />.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public static async Task<Result<TOkOut>> BindAsync<TOk, TOkOut>(
         this Task<Result<TOk>> task,
@@ -43,8 +41,6 @@ public static partial class TaskExtensions
     /// <typeparam name="TOk">The OK type.</typeparam>
     /// <typeparam name="TOkOut">The output OK type.</typeparam>
     /// <returns>A <see cref="Task{TResult}" />.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public static async Task<Result<TOkOut>> BindAsync<TOk, TOkOut>(
         this Task<Result<TOk>> task,
@@ -68,8 +64,6 @@ public static partial class TaskExtensions
     /// <param name="bindFunc">The binding function.</param>
     /// <typeparam name="TOk">The OK type.</typeparam>
     /// <returns>A <see cref="Task{TResult}" />.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public static async Task<Result<TOk>> BindErrorAsync<TOk>(
         this Task<Result<TOk>> task,
@@ -91,8 +85,6 @@ public static partial class TaskExtensions
     /// <param name="bindFunc">The binding function.</param>
     /// <typeparam name="TOk">The OK type.</typeparam>
     /// <returns>A <see cref="Task{TResult}" />.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public static async Task<Result<TOk>> BindErrorAsync<TOk>(
         this Task<Result<TOk>> task,
@@ -115,8 +107,6 @@ public static partial class TaskExtensions
     /// <typeparam name="TOk">The OK type.</typeparam>
     /// <typeparam name="TOkOut">The output OK type.</typeparam>
     /// <returns>A <see cref="Task{TResult}" />.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public static async Task<Result<TOkOut>> MapAsync<TOk, TOkOut>(
         this Task<Result<TOk>> task,
@@ -139,8 +129,6 @@ public static partial class TaskExtensions
     /// <typeparam name="TOk">The OK type.</typeparam>
     /// <typeparam name="TOkOut">The output OK type.</typeparam>
     /// <returns>A <see cref="Task{TResult}" />.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public static async Task<Result<TOkOut>> MapAsync<TOk, TOkOut>(
         this Task<Result<TOk>> task,
@@ -162,8 +150,6 @@ public static partial class TaskExtensions
     /// <param name="mapErrorFunc">The mapping function.</param>
     /// <typeparam name="TOk">The OK type.</typeparam>
     /// <returns>A <see cref="Task{TResult}" />.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public static async Task<Result<TOk>> MapErrorAsync<TOk>(
         this Task<Result<TOk>> task,
@@ -186,8 +172,6 @@ public static partial class TaskExtensions
     /// <param name="mapErrorFunc">The mapping function.</param>
     /// <typeparam name="TOk">The OK type.</typeparam>
     /// <returns>A <see cref="Task{TResult}" />.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public static async Task<Result<TOk>> MapErrorAsync<TOk>(
         this Task<Result<TOk>> task,
@@ -211,8 +195,6 @@ public static partial class TaskExtensions
     /// <typeparam name="TOk">The OK type.</typeparam>
     /// <typeparam name="TOut">The output type.</typeparam>
     /// <returns>A <see cref="Task{TResult}" />.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public static async Task<TOut> MatchAsync<TOk, TOut>(
         this Task<Result<TOk>> task,
@@ -238,8 +220,6 @@ public static partial class TaskExtensions
     /// <typeparam name="TOk">The OK type.</typeparam>
     /// <typeparam name="TOut">The output type.</typeparam>
     /// <returns>A <see cref="Task{TResult}" />.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public static async Task<TOut> MatchAsync<TOk, TOut>(
         this Task<Result<TOk>> task,
@@ -264,8 +244,6 @@ public static partial class TaskExtensions
     /// <param name="errorFunc">The 'Error' action.</param>
     /// <typeparam name="TOk">The OK type.</typeparam>
     /// <returns>A <see cref="Task{TResult}" />.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public static async Task<Result<TOk>> TapAsync<TOk>(
         this Task<Result<TOk>> task,
@@ -297,8 +275,6 @@ public static partial class TaskExtensions
     /// <param name="errorAction">The 'Error' action.</param>
     /// <typeparam name="TOk">The OK type.</typeparam>
     /// <returns>A <see cref="Task{TResult}" />.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if state is Invalid.</exception>
-    /// <exception cref="UnreachableException">Thrown if the state is unknown.</exception>
     [SuppressMessage("ReSharper", "NullableWarningSuppressionIsUsed")]
     public static async Task<Result<TOk>> TapAsync<TOk>(
         this Task<Result<TOk>> task,

--- a/src/Monads/TaskExtensions.Result.cs
+++ b/src/Monads/TaskExtensions.Result.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using SleepingBear.Monad.Errors;
 
 namespace SleepingBear.Monad.Monads;

--- a/src/Monads/TaskExtensions.Result.cs
+++ b/src/Monads/TaskExtensions.Result.cs
@@ -27,14 +27,11 @@ public static partial class TaskExtensions
         ArgumentNullException.ThrowIfNull(task);
         ArgumentNullException.ThrowIfNull(bindFunc);
 
-        var result = await task.ConfigureAwait(false);
-        var (state, ok, error) = result;
-        return state switch
+        var (isOk, ok, error) = await task.ConfigureAwait(false);
+        return isOk switch
         {
-            ResultState.Ok => await bindFunc(ok!).ConfigureAwait(false),
-            ResultState.Error => new Result<TOkOut>(error!),
-            ResultState.Invalid => throw new InvalidOperationException(),
-            _ => throw new UnreachableException()
+            true => await bindFunc(ok!).ConfigureAwait(false),
+            false => new Result<TOkOut>(error!)
         };
     }
 
@@ -56,14 +53,11 @@ public static partial class TaskExtensions
         ArgumentNullException.ThrowIfNull(task);
         ArgumentNullException.ThrowIfNull(bindFunc);
 
-        var result = await task.ConfigureAwait(false);
-        var (state, ok, error) = result;
-        return state switch
+        var (isOk, ok, error) = await task.ConfigureAwait(false);
+        return isOk switch
         {
-            ResultState.Ok => bindFunc(ok!),
-            ResultState.Error => new Result<TOkOut>(error!),
-            ResultState.Invalid => throw new InvalidOperationException(),
-            _ => throw new UnreachableException()
+            true => bindFunc(ok!),
+            false => new Result<TOkOut>(error!)
         };
     }
 
@@ -84,15 +78,10 @@ public static partial class TaskExtensions
         ArgumentNullException.ThrowIfNull(task);
         ArgumentNullException.ThrowIfNull(bindFunc);
 
-        var result = await task.ConfigureAwait(false);
-        var (state, _, error) = result;
-        return state switch
-        {
-            ResultState.Ok => result,
-            ResultState.Error => await bindFunc(error!).ConfigureAwait(false),
-            ResultState.Invalid => throw new InvalidOperationException(),
-            _ => throw new UnreachableException()
-        };
+        var (isOk, _, error) = await task.ConfigureAwait(false);
+        return isOk
+            ? await task.ConfigureAwait(false)
+            : await bindFunc(error!).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -112,15 +101,10 @@ public static partial class TaskExtensions
         ArgumentNullException.ThrowIfNull(task);
         ArgumentNullException.ThrowIfNull(bindFunc);
 
-        var result = await task.ConfigureAwait(false);
-        var (state, _, error) = result;
-        return state switch
-        {
-            ResultState.Ok => result,
-            ResultState.Error => bindFunc(error!),
-            ResultState.Invalid => throw new InvalidOperationException(),
-            _ => throw new UnreachableException()
-        };
+        var (isOk, _, error) = await task.ConfigureAwait(false);
+        return isOk
+            ? await task.ConfigureAwait(false)
+            : bindFunc(error!);
     }
 
     /// <summary>
@@ -141,15 +125,10 @@ public static partial class TaskExtensions
         ArgumentNullException.ThrowIfNull(task);
         ArgumentNullException.ThrowIfNull(mapFunc);
 
-        var result = await task.ConfigureAwait(false);
-        var (state, ok, error) = result;
-        return state switch
-        {
-            ResultState.Ok => new Result<TOkOut>(await mapFunc(ok!).ConfigureAwait(false)),
-            ResultState.Error => new Result<TOkOut>(error!),
-            ResultState.Invalid => throw new InvalidOperationException(),
-            _ => throw new UnreachableException()
-        };
+        var (isOk, ok, error) = await task.ConfigureAwait(false);
+        return isOk
+            ? new Result<TOkOut>(await mapFunc(ok!).ConfigureAwait(false))
+            : new Result<TOkOut>(error!);
     }
 
     /// <summary>
@@ -170,15 +149,10 @@ public static partial class TaskExtensions
         ArgumentNullException.ThrowIfNull(task);
         ArgumentNullException.ThrowIfNull(mapFunc);
 
-        var result = await task.ConfigureAwait(false);
-        var (state, ok, error) = result;
-        return state switch
-        {
-            ResultState.Ok => new Result<TOkOut>(mapFunc(ok!)),
-            ResultState.Error => new Result<TOkOut>(error!),
-            ResultState.Invalid => throw new InvalidOperationException(),
-            _ => throw new UnreachableException()
-        };
+        var (isOk, ok, error) = await task.ConfigureAwait(false);
+        return isOk
+            ? new Result<TOkOut>(mapFunc(ok!))
+            : new Result<TOkOut>(error!);
     }
 
     /// <summary>
@@ -198,15 +172,10 @@ public static partial class TaskExtensions
         ArgumentNullException.ThrowIfNull(task);
         ArgumentNullException.ThrowIfNull(mapErrorFunc);
 
-        var result = await task.ConfigureAwait(false);
-        var (state, _, error) = result;
-        return state switch
-        {
-            ResultState.Ok => result,
-            ResultState.Error => new Result<TOk>(await mapErrorFunc(error!).ConfigureAwait(false)),
-            ResultState.Invalid => throw new InvalidOperationException(),
-            _ => throw new UnreachableException()
-        };
+        var (isOk, _, error) = await task.ConfigureAwait(false);
+        return isOk
+            ? await task.ConfigureAwait(false)
+            : new Result<TOk>(await mapErrorFunc(error!).ConfigureAwait(false));
     }
 
 
@@ -227,15 +196,10 @@ public static partial class TaskExtensions
         ArgumentNullException.ThrowIfNull(task);
         ArgumentNullException.ThrowIfNull(mapErrorFunc);
 
-        var result = await task.ConfigureAwait(false);
-        var (state, _, error) = result;
-        return state switch
-        {
-            ResultState.Ok => result,
-            ResultState.Error => new Result<TOk>(mapErrorFunc(error!)),
-            ResultState.Invalid => throw new InvalidOperationException(),
-            _ => throw new UnreachableException()
-        };
+        var (isOk, _, error) = await task.ConfigureAwait(false);
+        return isOk
+            ? await task.ConfigureAwait(false)
+            : new Result<TOk>(mapErrorFunc(error!));
     }
 
     /// <summary>
@@ -259,15 +223,10 @@ public static partial class TaskExtensions
         ArgumentNullException.ThrowIfNull(okFunc);
         ArgumentNullException.ThrowIfNull(errorFunc);
 
-        var result = await task.ConfigureAwait(false);
-        var (state, ok, error) = result;
-        return state switch
-        {
-            ResultState.Ok => await okFunc(ok!).ConfigureAwait(false),
-            ResultState.Error => await errorFunc(error!).ConfigureAwait(false),
-            ResultState.Invalid => throw new InvalidOperationException(),
-            _ => throw new UnreachableException()
-        };
+        var (isOk, ok, error) = await task.ConfigureAwait(false);
+        return isOk
+            ? await okFunc(ok!).ConfigureAwait(false)
+            : await errorFunc(error!).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -291,15 +250,10 @@ public static partial class TaskExtensions
         ArgumentNullException.ThrowIfNull(okFunc);
         ArgumentNullException.ThrowIfNull(errorFunc);
 
-        var result = await task.ConfigureAwait(false);
-        var (state, ok, error) = result;
-        return state switch
-        {
-            ResultState.Ok => okFunc(ok!),
-            ResultState.Error => errorFunc(error!),
-            ResultState.Invalid => throw new InvalidOperationException(),
-            _ => throw new UnreachableException()
-        };
+        var (isOk, ok, error) = await task.ConfigureAwait(false);
+        return isOk
+            ? okFunc(ok!)
+            : errorFunc(error!);
     }
 
     /// <summary>
@@ -322,23 +276,17 @@ public static partial class TaskExtensions
         ArgumentNullException.ThrowIfNull(okFunc);
         ArgumentNullException.ThrowIfNull(errorFunc);
 
-        var result = await task.ConfigureAwait(false);
-        var (state, ok, error) = result;
-        switch (state)
+        var (isOk, ok, error) = await task.ConfigureAwait(false);
+        if (isOk)
         {
-            case ResultState.Ok:
-                await okFunc(ok!).ConfigureAwait(false);
-                break;
-            case ResultState.Error:
-                await errorFunc(error!).ConfigureAwait(false);
-                break;
-            case ResultState.Invalid:
-                throw new InvalidOperationException();
-            default:
-                throw new UnreachableException();
+            await okFunc(ok!).ConfigureAwait(false);
+        }
+        else
+        {
+            await errorFunc(error!).ConfigureAwait(false);
         }
 
-        return result;
+        return await task.ConfigureAwait(false);
     }
 
     /// <summary>
@@ -361,22 +309,16 @@ public static partial class TaskExtensions
         ArgumentNullException.ThrowIfNull(okAction);
         ArgumentNullException.ThrowIfNull(errorAction);
 
-        var result = await task.ConfigureAwait(false);
-        var (state, ok, error) = result;
-        switch (state)
+        var (isOk, ok, error) = await task.ConfigureAwait(false);
+        if (isOk)
         {
-            case ResultState.Ok:
-                okAction(ok!);
-                break;
-            case ResultState.Error:
-                errorAction(error!);
-                break;
-            case ResultState.Invalid:
-                throw new InvalidOperationException();
-            default:
-                throw new UnreachableException();
+            okAction(ok!);
+        }
+        else
+        {
+            errorAction(error!);
         }
 
-        return result;
+        return await task.ConfigureAwait(false);
     }
 }

--- a/src/Monads/Validation.cs
+++ b/src/Monads/Validation.cs
@@ -11,6 +11,16 @@ public readonly record struct Validation<TValue> where TValue : notnull
     private readonly ImmutableList<Error>? _errors;
     private readonly TValue? _value;
 
+    /// <summary>
+    ///     Default constructor.
+    /// </summary>
+    public Validation()
+    {
+        this._value = default;
+        this._errors = ImmutableList<Error>.Empty;
+        this.IsValid = false;
+    }
+
     internal Validation(TValue value)
     {
         this._value = value;
@@ -24,17 +34,7 @@ public readonly record struct Validation<TValue> where TValue : notnull
         this._errors = errors ?? ImmutableList<Error>.Empty;
         this.IsValid = false;
     }
-
-    /// <summary>
-    ///     Default constructor.
-    /// </summary>
-    public Validation()
-    {
-        this._value = default;
-        this._errors = ImmutableList<Error>.Empty;
-        this.IsValid = false;
-    }
-
+    
     /// <summary>
     ///     Is valid?
     /// </summary>

--- a/src/Monads/Validation.cs
+++ b/src/Monads/Validation.cs
@@ -34,7 +34,7 @@ public readonly record struct Validation<TValue> where TValue : notnull
         this._errors = errors ?? ImmutableList<Error>.Empty;
         this.IsValid = false;
     }
-    
+
     /// <summary>
     ///     Is valid?
     /// </summary>


### PR DESCRIPTION
- Simply monad state to simple boolean flag
- Replace switch statements/expressions with ternary operators
- Update tests
- Reformat code